### PR TITLE
Small UX improvements

### DIFF
--- a/axlib/src/main.m
+++ b/axlib/src/main.m
@@ -542,9 +542,18 @@ napi_value AXCheckIfStandardWindow (napi_env env, napi_callback_info info) {
         _AXUIElementGetWindow(windows[i], &current_wid);
 
         if (current_wid == wid) {
-            napi_value result;
-            napi_create_int32(env, 1, &result);
-            return result;
+            NSString* axSubrole;
+
+            if (AXUIElementCopyAttributeValue(windows[i], kAXSubroleAttribute, (CFTypeRef*)&axSubrole) == 0) {
+                bool isStandardWindow = !CFEqual(axSubrole, kAXUnknownSubrole);
+                CFRelease(axSubrole);
+
+                if (isStandardWindow) {
+                    napi_value result;
+                    napi_create_int32(env, 1, &result);
+                    return result;
+                }
+            }
         }
     }
 

--- a/lib/preview.js
+++ b/lib/preview.js
@@ -98,7 +98,8 @@ class ThumbComponent extends Component {
         painter.drawText(w.name, { x: PREVIEW_GAP, y: PREVIEW_GAP, width: (bounds.width - 16) - PREVIEW_GAP * 2, height: CAPTION_FONT.getSize() / 2 }, {
             font: CAPTION_FONT, 
             color: theme.preview['caption:color'], 
-            wrap: false
+            wrap: false,
+            ellipsis: true
         });
 
         let imgBoundWidth = bounds.width - PREVIEW_GAP * 2;


### PR DESCRIPTION
1. Add ellipsis to preview caption text

    **Before**
    <img width="491" alt="image" src="https://github.com/PepsRyuu/dock-window-preview/assets/22344007/39222768-04b4-44f2-99aa-bc23bb79a385">

    **After**
    <img width="491" alt="image" src="https://github.com/PepsRyuu/dock-window-preview/assets/22344007/b1f9ed5d-a342-4262-9ba5-9308ba45c5dc">

2. Skip preview for unknown windows like Chrome find bar

    <img width="491" alt="image" src="https://github.com/PepsRyuu/dock-window-preview/assets/22344007/8e2455cf-7d45-49e7-b7ec-3edd220c73bb">

3. ~~Hide preview when dock icon is clicked~~
   
    ```
    // We want to hide the preview if you click anywhere outside of the preview.
    // The only exception is if we're clicking on the dock, otherwise it will flicker
    // the preview and show it again.
    ```

    ~~I removed the block of code associated with this comment and now the preview hides as expected. I haven't seen any flickering issues so far but am probably missing something.~~